### PR TITLE
Fix badly resolved merge conflicts from PR #4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-
-# Installation
+# gifify
 
 Convert videos to optimized GIFs using ffmpeg's two-pass palette technique.
 
@@ -99,12 +98,4 @@ This removes `~/.gifify/` and cleans the source line from your shell RC files.
 
 ## License
 
-The script verifies that `ffmpeg` is installed (using Homebrew or `apt-get` when possible), downloads the `gifify.sh` script, and sources it from your `~/.zshrc`. After running the installer open a new shell or run `source ~/.zshrc` to use the `gifify` command.
-
-# Development
-
-This repository uses GitHub Actions to run `shellcheck` on every commit.
-
-
-The script checks for `ffmpeg` and installs it if missing (using Homebrew or `apt-get`). It downloads the latest `gifify.sh` and adds it to your `~/.zshrc` so you can start using the function in new terminals. The installer stores a version file in `~/.gifify` and will re-download the script when a newer version is available. After installation run `source ~/.zshrc` or open a new shell and invoke `gifify`.
-
+[MIT](LICENSE)

--- a/gifify.sh
+++ b/gifify.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# gifify function
+# gifify — convert videos to optimized GIFs using ffmpeg's two-pass palette technique
+# https://github.com/pidoshva/gifify
 
 GIFIFY_VERSION="1.1.0"
 
@@ -48,14 +49,55 @@ Options:
   -h, --help            Show this help message
   -v, --version         Show version"
 
-  local input="$1"
-  local filename
-  filename=$(basename "$input")
-  local name="${filename%.*}"
-  local output_dir="$HOME/Desktop/gifified"
-  mkdir -p "$output_dir"
-  local output="${output_dir}/${name}.gif"
-  local width="1920"  # Default: 1080p width
+    # ── Parse arguments ─────────────────────────────────────────────
+    local input="" output="" fps=15 width=1920
+
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            -h|--help)
+                echo "$_gifify_usage"
+                return 0
+                ;;
+            -v|--version)
+                echo "gifify $GIFIFY_VERSION"
+                return 0
+                ;;
+            -o|--output)
+                if [ -z "${2:-}" ]; then
+                    echo "Error: --output requires a path argument." >&2
+                    return 1
+                fi
+                output="$2"
+                shift 2
+                ;;
+            --fps)
+                if [ -z "${2:-}" ]; then
+                    echo "Error: --fps requires a numeric argument." >&2
+                    return 1
+                fi
+                fps="$2"
+                shift 2
+                ;;
+            --1080p) width=1920; shift ;;
+            --720p)  width=1280; shift ;;
+            --480p)  width=854;  shift ;;
+            --360p)  width=640;  shift ;;
+            -*)
+                echo "Error: unknown option '$1'" >&2
+                echo "$_gifify_usage" >&2
+                return 1
+                ;;
+            *)
+                if [ -z "$input" ]; then
+                    input="$1"
+                else
+                    echo "Error: unexpected argument '$1'" >&2
+                    return 1
+                fi
+                shift
+                ;;
+        esac
+    done
 
     # ── Validate input ──────────────────────────────────────────────
     if [ -z "$input" ]; then

--- a/install.sh
+++ b/install.sh
@@ -45,27 +45,8 @@ do_uninstall() {
         info "Removed $GIFIFY_DIR"
     fi
 
-# URL for downloading the script
-GIFIFY_URL="https://raw.githubusercontent.com/pidoshva/gifify/main/gifify.sh"
-
-echo "Downloading gifify script..."
-curl -fsSL "$GIFIFY_URL" -o "$GIFIFY_DIR/gifify.sh"
-
-# Ensure gifify function is loaded in zsh
-ZSHRC="$HOME/.zshrc"
-SOURCE_LINE="source \"$HOME/.gifify/gifify.sh\""
-if ! grep -Fq 'gifify.sh' "$ZSHRC" 2>/dev/null; then
-    echo "Adding gifify function to $ZSHRC..."
-    echo -e "\n# Load gifify function\n$SOURCE_LINE" >> "$ZSHRC"
-fi
-
-# Source the function for current session if running zsh
-if [ -n "$ZSH_VERSION" ]; then
-# shellcheck disable=SC1090
-
-# URLs for downloading the script and version
-GIFIFY_URL="https://raw.githubusercontent.com/pidoshva/gifify/main/gifify.sh"
-VERSION_URL="https://raw.githubusercontent.com/pidoshva/gifify/main/VERSION"
+    local rc_file
+    rc_file="$(detect_rc_file)"
 
     # Also clean the other rc file in case they switched shells
     local rc_files=("$rc_file")
@@ -86,22 +67,63 @@ VERSION_URL="https://raw.githubusercontent.com/pidoshva/gifify/main/VERSION"
 
 # ── Install ─────────────────────────────────────────────────────────
 
-GIFIFY_DIR="$HOME/.gifify"
-mkdir -p "$GIFIFY_DIR"
-cp "gifify.sh" "$GIFIFY_DIR/gifify.sh"
+do_install() {
+    echo "Installing gifify..."
 
-# Ensure gifify function is loaded in zsh
-ZSHRC="$HOME/.zshrc"
-SOURCE_LINE="source \"$HOME/.gifify/gifify.sh\""
-if ! grep -Fq 'gifify.sh' "$ZSHRC" 2>/dev/null; then
-    echo "Adding gifify function to $ZSHRC..."
-    echo -e "\n# Load gifify function\n$SOURCE_LINE" >> "$ZSHRC"
-fi
+    # 1. Ensure ffmpeg is available
+    if ! command -v ffmpeg >/dev/null 2>&1; then
+        info "ffmpeg not found."
+        install_ffmpeg || exit 1
+    fi
 
-# Source the function for current session if running zsh
-if [ -n "$ZSH_VERSION" ]; then
+    # 2. Create install directory
+    mkdir -p "$GIFIFY_DIR"
 
-    source "$ZSHRC"
-fi
+    # 3. Copy or download gifify.sh
+    local script_dir
+    script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-echo "gifify installed! Open a new terminal or run 'source $ZSHRC' to start using it."
+    if [ -f "$script_dir/gifify.sh" ]; then
+        # Local clone install
+        cp "$script_dir/gifify.sh" "$GIFIFY_DIR/gifify.sh"
+        info "Copied gifify.sh from local repo"
+        # Copy VERSION if present
+        if [ -f "$script_dir/VERSION" ]; then
+            cp "$script_dir/VERSION" "$GIFIFY_DIR/VERSION"
+        fi
+    else
+        # Remote install (curl pipe)
+        info "Downloading gifify.sh..."
+        curl -fsSL "$REPO_URL/gifify.sh" -o "$GIFIFY_DIR/gifify.sh"
+        curl -fsSL "$REPO_URL/VERSION" -o "$GIFIFY_DIR/VERSION"
+    fi
+
+    chmod +x "$GIFIFY_DIR/gifify.sh"
+
+    # 4. Add source line to shell RC file
+    local rc_file source_line
+    rc_file="$(detect_rc_file)"
+    source_line="source \"$GIFIFY_DIR/gifify.sh\""
+
+    if ! grep -Fq 'gifify.sh' "$rc_file" 2>/dev/null; then
+        info "Adding gifify to $rc_file..."
+        printf '\n# Load gifify\n%s\n' "$source_line" >> "$rc_file"
+    else
+        info "gifify already configured in $rc_file"
+    fi
+
+    echo ""
+    echo "gifify installed! Run 'source $rc_file' or open a new terminal to start using it."
+    echo "Usage: gifify <video_file> [--720p|--480p|--360p]"
+}
+
+# ── Main ────────────────────────────────────────────────────────────
+
+main() {
+    case "${1:-}" in
+        --uninstall) do_uninstall ;;
+        *)           do_install   ;;
+    esac
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- Restores correct `gifify.sh` — argument parsing loop, `fps` variable, no duplicate declarations
- Restores correct `install.sh` — clean `do_uninstall()`/`do_install()` functions, no old spliced code
- Restores correct `README.md` — proper `# gifify` title, no old content appended after License

The merge of PR #4 (gifify-init → main) incorrectly resolved conflicts by mixing old code into the rewritten files.

## Test plan

- [ ] `shellcheck gifify.sh install.sh` passes clean
- [ ] `bash gifify.sh --help` shows usage
- [ ] `bash gifify.sh --version` shows `1.1.0`
- [ ] `bash gifify.sh nonexistent.mp4` shows error
- [ ] `./install.sh` installs correctly
- [ ] `./install.sh --uninstall` removes cleanly