### PR TITLE
Harden install and runtime for production use

### DIFF
--- a/gifify.sh
+++ b/gifify.sh
@@ -112,7 +112,7 @@ _gifify_spinner_start() {
     (
         local i=0
         while true; do
-            local frame="${frames:i%${#frames}:1}"
+            local frame="${frames:$(( i % ${#frames} )):1}"
             printf "\r${_CLR_CYAN}  %s${_CLR_RESET} ${_CLR_DIM}%s${_CLR_RESET}" "$frame" "$msg"
             i=$((i + 1))
             sleep 0.08
@@ -186,6 +186,16 @@ Options:
             --fps)
                 if [ -z "${2:-}" ]; then
                     _gifify_err "--fps requires a numeric argument"
+                    return 1
+                fi
+                case "$2" in
+                    ''|*[!0-9]*)
+                        _gifify_err "--fps must be a positive integer (got '$2')"
+                        return 1
+                        ;;
+                esac
+                if [ "$2" -lt 1 ]; then
+                    _gifify_err "--fps must be at least 1"
                     return 1
                 fi
                 fps="$2"

--- a/install.sh
+++ b/install.sh
@@ -74,6 +74,18 @@ do_install() {
     if ! command -v ffmpeg >/dev/null 2>&1; then
         info "ffmpeg not found."
         install_ffmpeg || exit 1
+
+        # Verify it actually landed on PATH
+        if ! command -v ffmpeg >/dev/null 2>&1; then
+            error "ffmpeg installed but is not on PATH. Open a new terminal or install it manually, then re-run."
+            exit 1
+        fi
+    fi
+
+    # ffprobe ships with ffmpeg and is required for input analysis
+    if ! command -v ffprobe >/dev/null 2>&1; then
+        error "ffprobe not found (normally bundled with ffmpeg). Please reinstall ffmpeg."
+        exit 1
     fi
 
     # 2. Create install directory
@@ -93,9 +105,20 @@ do_install() {
         fi
     else
         # Remote install (curl pipe)
+        if ! command -v curl >/dev/null 2>&1; then
+            error "curl is required for remote install but was not found. Install curl or clone the repo and run ./install.sh"
+            exit 1
+        fi
         info "Downloading gifify.sh..."
         curl -fsSL "$REPO_URL/gifify.sh" -o "$GIFIFY_DIR/gifify.sh"
-        curl -fsSL "$REPO_URL/VERSION" -o "$GIFIFY_DIR/VERSION"
+        # VERSION is optional (gifify.sh carries its own GIFIFY_VERSION)
+        curl -fsSL "$REPO_URL/VERSION" -o "$GIFIFY_DIR/VERSION" 2>/dev/null || true
+    fi
+
+    # Verify we ended up with a usable script
+    if [ ! -s "$GIFIFY_DIR/gifify.sh" ]; then
+        error "gifify.sh is missing or empty after install. Aborting."
+        exit 1
     fi
 
     chmod +x "$GIFIFY_DIR/gifify.sh"


### PR DESCRIPTION
Makes the install one-liner and the runtime robust enough for anyone to install and run, with dependencies installed and requirements enforced.

## Fixes

**Critical — spinner crashed under zsh**
The frame-cycling substring `${frames:i%${#frames}:1}` made zsh throw `unrecognized modifier 'i'` on every run. zsh is the default shell on modern macOS — exactly where `install.sh` sources the script — so every Mac user saw the error (the GIF still produced, but with a visible error spewed each run). Reworked to use arithmetic expansion, which parses correctly in both bash and zsh.

**`--fps` input validation**
`--fps abc` / `--fps 0` previously passed straight to ffmpeg and failed mid-encode with a cryptic message. Now validated as a positive integer up front.

**Installer hardening (`install.sh`)**
- Verify `ffmpeg` is actually on `PATH` after the install step (a package manager can exit 0 without exposing the binary).
- Enforce `ffprobe` (used for input analysis; normally bundled with ffmpeg).
- Check for `curl` before the remote download path, with a clear fallback message.
- Verify the installed `gifify.sh` is non-empty before activating it; make the optional `VERSION` download non-fatal.

## Verification
- `shellcheck` clean on both scripts.
- Sourced and ran a real conversion under both bash and zsh — zsh is now error-free.
- Full install → run → uninstall cycle in an isolated `HOME` under zsh.